### PR TITLE
Fix iOS nav padding and improve bottom sheet designs

### DIFF
--- a/composeApp/src/commonMain/kotlin/common/ui/components/bottomsheet/RatingBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/common/ui/components/bottomsheet/RatingBottomSheet.kt
@@ -1,7 +1,9 @@
 package common.ui.components.bottomsheet
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -9,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
@@ -22,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.text.font.FontWeight
@@ -34,10 +38,14 @@ import cinetracker_kmp.composeapp.generated.resources.rating_bottom_sheet_header
 import cinetracker_kmp.composeapp.generated.resources.rating_bottom_sheet_save_button
 import common.ui.components.button.GenericButton
 import common.ui.theme.PrimaryBlueColor
+import common.ui.theme.PrimaryRedColor
 import common.ui.theme.SecondaryGreyColor
 import common.util.UiConstants.DEFAULT_MARGIN
 import common.util.UiConstants.DEFAULT_PADDING
 import common.util.UiConstants.LARGE_MARGIN
+import common.util.UiConstants.RATING_SLIDER_THUMB_ELEVATION
+import common.util.UiConstants.RATING_SLIDER_THUMB_SIZE
+import common.util.UiConstants.RATING_SLIDER_TRACK_HEIGHT
 import common.util.platform.AppHaptics
 import kotlin.math.round
 import org.jetbrains.compose.resources.painterResource
@@ -73,7 +81,7 @@ fun RatingBottomSheet(
                     painter = painterResource(Res.drawable.ic_star),
                     contentDescription = null,
                     modifier = Modifier
-                        .size(48.dp)
+                        .size(56.dp)
                         .padding(bottom = 8.dp),
                     colorFilter = ColorFilter.tint(PrimaryBlueColor)
                 )
@@ -84,7 +92,7 @@ fun RatingBottomSheet(
                 }
 
                 Text(
-                    text = ratingText ?: "0",
+                    text = ratingText ?: "-",
                     style = MaterialTheme.typography.displayMedium.copy(
                         fontWeight = FontWeight.Bold,
                         fontSize = 56.sp
@@ -113,13 +121,29 @@ fun RatingBottomSheet(
                 },
                 valueRange = 0f..10f,
                 steps = 99,
-                colors = SliderDefaults.colors(
-                    thumbColor = PrimaryBlueColor,
-                    activeTrackColor = PrimaryBlueColor,
-                    inactiveTrackColor = PrimaryBlueColor.copy(alpha = 0.24f),
-                    activeTickColor = Color.Transparent,
-                    inactiveTickColor = Color.Transparent
-                ),
+                thumb = {
+                    Box(
+                        modifier = Modifier
+                            .size(RATING_SLIDER_THUMB_SIZE.dp)
+                            .shadow(RATING_SLIDER_THUMB_ELEVATION.dp, CircleShape)
+                            .background(PrimaryBlueColor, CircleShape)
+                    )
+                },
+                track = { sliderState ->
+                    SliderDefaults.Track(
+                        sliderState = sliderState,
+                        modifier = Modifier.height(RATING_SLIDER_TRACK_HEIGHT.dp),
+                        colors = SliderDefaults.colors(
+                            activeTrackColor = PrimaryBlueColor,
+                            inactiveTrackColor = PrimaryBlueColor.copy(alpha = 0.24f),
+                            activeTickColor = Color.Transparent,
+                            inactiveTickColor = Color.Transparent
+                        ),
+                        thumbTrackGapSize = 0.dp,
+                        trackInsideCornerSize = 0.dp,
+                        drawStopIndicator = null
+                    )
+                },
                 modifier = Modifier.fillMaxWidth()
             )
 
@@ -147,7 +171,7 @@ fun RatingBottomSheet(
                 ) {
                     Text(
                         text = stringResource(Res.string.personal_ratings_clear),
-                        color = SecondaryGreyColor,
+                        color = PrimaryRedColor,
                         style = MaterialTheme.typography.labelLarge.copy(
                             fontWeight = FontWeight.Medium
                         )

--- a/composeApp/src/commonMain/kotlin/common/util/UiConstants.kt
+++ b/composeApp/src/commonMain/kotlin/common/util/UiConstants.kt
@@ -43,6 +43,11 @@ object UiConstants {
     const val BROWSE_TAB_ROW_OFFSET_HEIGHT = 10
     const val BROWSE_SORT_ICON_SIZE = 32
 
+    // Rating Slider
+    const val RATING_SLIDER_THUMB_SIZE = 28
+    const val RATING_SLIDER_THUMB_ELEVATION = 4
+    const val RATING_SLIDER_TRACK_HEIGHT = 12
+
     // Details
     const val DETAILS_TITLE_IMAGE_OFFSET_PERCENT = 0.7f
     const val DETAILS_CAST_PICTURE_SIZE = 100

--- a/composeApp/src/commonMain/kotlin/features/watchlist/ui/components/WatchlistCardOptions.kt
+++ b/composeApp/src/commonMain/kotlin/features/watchlist/ui/components/WatchlistCardOptions.kt
@@ -1,36 +1,21 @@
 package features.watchlist.ui.components
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import cinetracker_kmp.composeapp.generated.resources.Res
 import cinetracker_kmp.composeapp.generated.resources.move_to_list_option_popup_menu
 import cinetracker_kmp.composeapp.generated.resources.move_to_other_list_header
 import cinetracker_kmp.composeapp.generated.resources.move_to_other_list_item
 import cinetracker_kmp.composeapp.generated.resources.remove_option_popup_menu
 import common.ui.components.bottomsheet.GenericBottomSheet
+import common.ui.components.bottomsheet.SortButton
 import common.ui.components.popup.GenericPopupMenu
 import common.ui.components.popup.PopupMenuItem
 import common.util.Constants.DEFAULT_LISTS_SIZE
-import common.util.UiConstants.DEFAULT_PADDING
-import common.util.UiConstants.LARGE_MARGIN
-import common.util.UiConstants.LARGE_PADDING
 import common.util.capitalized
 import features.watchlist.ui.model.DefaultLists
 import org.jetbrains.compose.resources.stringResource
@@ -151,37 +136,20 @@ private fun OtherListsPanel(
         },
         headerText = stringResource(resource = Res.string.move_to_other_list_header)
     ) {
-        LazyColumn {
-            items(allLists) { list ->
-                val listName = if (list.tabResId != null) {
-                    stringResource(resource = list.tabResId!!)
-                } else {
-                    list.tabName
-                }
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable {
-                            onMoveItemToList(list.listId)
-                            dismissBottomSheet()
-                        }
-                ) {
-                    Column {
-                        Spacer(modifier = Modifier.height(LARGE_PADDING.dp))
-                        Text(
-                            modifier = Modifier.padding(horizontal = DEFAULT_PADDING.dp),
-                            text = listName?.capitalized().orEmpty(),
-                            style = MaterialTheme.typography.bodyMedium,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                        Spacer(modifier = Modifier.height(LARGE_PADDING.dp))
-                    }
-                }
+        allLists.forEach { list ->
+            val listName = if (list.tabResId != null) {
+                stringResource(resource = list.tabResId!!)
+            } else {
+                list.tabName
             }
-            item {
-                Spacer(modifier = Modifier.height(LARGE_MARGIN.dp))
-            }
+            SortButton(
+                text = listName?.capitalized().orEmpty(),
+                textColor = MaterialTheme.colorScheme.onPrimary,
+                onClick = {
+                    onMoveItemToList(list.listId)
+                    dismissBottomSheet()
+                }
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/navigation/components/MainNavBar.kt
+++ b/composeApp/src/commonMain/kotlin/navigation/components/MainNavBar.kt
@@ -50,11 +50,13 @@ fun MainNavBar(navController: NavController, navBarItems: List<MainNavBarItem>) 
             NavigationBarItem(
                 selected = isSelected,
                 onClick = {
-                    AppHaptics.light()
-                    navigateToTopLevelDestination(
-                        navController = navController,
-                        destination = item.route
-                    )
+                    if (!isSelected) {
+                        AppHaptics.light()
+                        navigateToTopLevelDestination(
+                            navController = navController,
+                            destination = item.route
+                        )
+                    }
                 },
                 icon = {
                     Column(

--- a/composeApp/src/iosMain/kotlin/common/util/platform/PlatformUtils.kt
+++ b/composeApp/src/iosMain/kotlin/common/util/platform/PlatformUtils.kt
@@ -12,6 +12,7 @@ const val DEFAULT_COUNTRY = "US"
 
 actual object PlatformUtils {
     actual val isIOS: Boolean = true
+
     @OptIn(ExperimentalNativeApi::class)
     actual val isDebugBuild: Boolean = Platform.isDebugBinary
     actual fun getUserLanguage(): String {


### PR DESCRIPTION
## Summary
- Fix iOS padding bug when re-clicking a selected nav bar tab
- Restyle watchlist OtherListsPanel to use SortButton, matching the browse sort bottom sheet pattern
- Redesign personal rating slider with larger custom thumb, thicker track, and no stop indicator
- Polish rating modal: larger star icon, dash for unrated state, red clear button