### PR TITLE
chore: refactor settings to follow project patterns

### DIFF
--- a/.claude/rules/features_details.md
+++ b/.claude/rules/features_details.md
@@ -213,3 +213,41 @@
 - **Watchlist toggle snackbar:** 500ms delay (`DELAY_UPDATE_POPUP_TEXT_MS`) before updating `contentInListStatus` to show feedback first
 - **Multi-list support:** `OtherListsBottomSheet` shows all lists with checkmarks; `contentInListStatus` map tracks membership per list
 - **ViewModel injection:** Uses `koinViewModel { parametersOf(contentId, mediaType) }` — `contentId` and `mediaType` are constructor parameters
+
+---
+
+## Settings
+
+**Route:** Nested navigation graph under `SettingsGraphRoute` with 3 sub-routes: `SettingsRoute`, `LanguagePickerRoute`, `RegionPickerRoute`.
+**Purpose:** User preferences for app language, content region, and engagement notifications.
+
+### Structure
+- `SettingsEvent.kt` — `NotificationPermissionResult(granted)`, `DisableNotifications`
+- `SettingsInteractor.kt` — Language/region fallback logic, notification state, settings persistence
+- `SettingsViewModel.kt` — Manages display state for language, region, notifications; uses `onEvent()` pattern
+- `SettingsView.kt` — Main settings screen (avatar, language row, region row, notifications toggle, version)
+- `LanguagePickerView.kt` — Radio-button language selection with save-on-back
+- `RegionPickerView.kt` — Radio-button region selection with save-on-back
+- `components/` — `ProfileAvatar`, `SettingsRow`, `SettingsToggleRow`, `PickerItemRow`, `PickerTopBar`
+
+### State (StateFlows on SettingsViewModel)
+| Field | Type | Description |
+|---|---|---|
+| `currentLanguageDisplay` | `String` | Display name of current language (e.g., "Português") |
+| `currentRegionDisplay` | `String` | Display name of current region (e.g., "Brazil") |
+| `notificationsEnabled` | `Boolean` | Whether engagement reminders are on |
+
+### Data Flow
+1. `init` → `refreshSettings()` reads current language/region/notification state from `SettingsInteractor`
+2. `settingsInteractor.settingsChanged` SharedFlow collected in `init` → auto-refreshes display when pickers save changes
+3. Picker screens inject `SettingsInteractor` directly via `koinInject()` — they are leaf screens that read/write settings without observing ViewModel state
+4. Picker save (`setAppLanguage`/`setAppRegion`) emits `settingsChanged` → SettingsViewModel auto-refreshes
+
+### Special Behaviors
+- **Language fallback chain:** stored value → device locale (if supported) → language family mapping (`pt` → `pt-BR`, `es` → `es-ES`) → `en-US`
+- **Region fallback chain:** stored value → device country (if in supported list) → `US`
+- **Supported languages:** en-US, es-ES, pt-BR (3 languages)
+- **Supported regions:** 40 country codes across Americas, Europe, Asia, Africa
+- **Notification toggle:** Enabling requests runtime permission; granted → schedules reminders, denied → no-op
+- **Settings change emission:** `settingsChanged` only emits when the value actually changes, preventing no-op refresh cycles
+- **Picker ordering:** Current selection shown first, remaining items sorted alphabetically below a divider

--- a/composeApp/src/androidUnitTest/kotlin/features/details/ui/DetailsViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/features/details/ui/DetailsViewModelTest.kt
@@ -504,6 +504,7 @@ class DetailsViewModelTest {
 
             val viewModel = createViewModel()
             advanceUntilIdle()
+            awaitIO() // let collectContentInListStatus IO coroutine update _contentInListStatus
 
             viewModel.setPersonalRating(8.0f)
             awaitIO()

--- a/composeApp/src/androidUnitTest/kotlin/features/settings/domain/SettingsInteractorTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/features/settings/domain/SettingsInteractorTest.kt
@@ -1,5 +1,6 @@
 package features.settings.domain
 
+import app.cash.turbine.test
 import common.util.platform.PlatformUtils
 import database.repository.SettingsRepository
 import io.mockk.MockKAnnotations
@@ -13,6 +14,7 @@ import io.mockk.verify
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -121,6 +123,26 @@ class SettingsInteractorTest {
         verify(exactly = 0) { PlatformUtils.applyAppLocale(any()) }
     }
 
+    @Test
+    fun `setAppLanguage emits settingsChanged when language changes`() = runTest {
+        every { settingsRepository.getAppLanguage() } returns "en-US"
+
+        interactor.settingsChanged.test {
+            interactor.setAppLanguage("pt-BR")
+            awaitItem()
+        }
+    }
+
+    @Test
+    fun `setAppLanguage does not emit settingsChanged when language unchanged`() = runTest {
+        every { settingsRepository.getAppLanguage() } returns "pt-BR"
+
+        interactor.settingsChanged.test {
+            interactor.setAppLanguage("pt-BR")
+            expectNoEvents()
+        }
+    }
+
     // endregion
 
     // region getAppRegion
@@ -160,9 +182,34 @@ class SettingsInteractorTest {
 
     @Test
     fun `setAppRegion delegates to repository`() {
+        every { settingsRepository.getAppRegion() } returns "US"
+        every { PlatformUtils.getUserCountry() } returns "US"
+
         interactor.setAppRegion("BR")
 
         verify { settingsRepository.setAppRegion("BR") }
+    }
+
+    @Test
+    fun `setAppRegion emits settingsChanged when region changes`() = runTest {
+        every { settingsRepository.getAppRegion() } returns "US"
+        every { PlatformUtils.getUserCountry() } returns "US"
+
+        interactor.settingsChanged.test {
+            interactor.setAppRegion("BR")
+            awaitItem()
+        }
+    }
+
+    @Test
+    fun `setAppRegion does not emit settingsChanged when region unchanged`() = runTest {
+        every { settingsRepository.getAppRegion() } returns "BR"
+        every { PlatformUtils.getUserCountry() } returns "BR"
+
+        interactor.settingsChanged.test {
+            interactor.setAppRegion("BR")
+            expectNoEvents()
+        }
     }
 
     // endregion

--- a/composeApp/src/androidUnitTest/kotlin/features/settings/ui/SettingsViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/features/settings/ui/SettingsViewModelTest.kt
@@ -4,6 +4,7 @@ import common.util.platform.AppNotifications
 import features.settings.domain.LanguageItem
 import features.settings.domain.RegionItem
 import features.settings.domain.SettingsInteractor
+import features.settings.events.SettingsEvent
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.mockk
@@ -98,11 +99,11 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `enabling notifications calls interactor and schedules reminders`() {
+    fun `NotificationPermissionResult granted enables notifications and schedules reminders`() {
         setupDefaultMocks()
         val viewModel = createViewModel()
 
-        viewModel.onNotificationPermissionResult(true)
+        viewModel.onEvent(SettingsEvent.NotificationPermissionResult(granted = true))
 
         verify { settingsInteractor.setNotificationsEnabled(true) }
         verify { AppNotifications.scheduleEngagementReminders() }
@@ -110,11 +111,11 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `disabling notifications calls interactor and cancels reminders`() {
+    fun `DisableNotifications disables notifications and cancels reminders`() {
         setupDefaultMocks(notificationsEnabled = true)
         val viewModel = createViewModel()
 
-        viewModel.disableNotifications()
+        viewModel.onEvent(SettingsEvent.DisableNotifications)
 
         verify { settingsInteractor.setNotificationsEnabled(false) }
         verify { AppNotifications.cancelEngagementReminders() }
@@ -122,31 +123,14 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `denied notification permission does not enable notifications`() {
+    fun `NotificationPermissionResult denied does not enable notifications`() {
         setupDefaultMocks()
         val viewModel = createViewModel()
 
-        viewModel.onNotificationPermissionResult(false)
+        viewModel.onEvent(SettingsEvent.NotificationPermissionResult(granted = false))
 
         verify(exactly = 0) { settingsInteractor.setNotificationsEnabled(any()) }
         assertFalse(viewModel.notificationsEnabled.value)
-    }
-
-    @Test
-    fun `refreshSettings updates display values after language change`() {
-        setupDefaultMocks(language = "en-US", region = "US")
-        val viewModel = createViewModel()
-
-        assertEquals("English", viewModel.currentLanguageDisplay.value)
-        assertEquals("United States", viewModel.currentRegionDisplay.value)
-
-        every { settingsInteractor.getAppLanguage() } returns "pt-BR"
-        every { settingsInteractor.getAppRegion() } returns "BR"
-
-        viewModel.refreshSettings()
-
-        assertEquals("Portugu\u00eas", viewModel.currentLanguageDisplay.value)
-        assertEquals("Brazil", viewModel.currentRegionDisplay.value)
     }
 
     @Test
@@ -154,7 +138,7 @@ class SettingsViewModelTest {
         val settingsChangedFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
         setupDefaultMocks(language = "en-US", region = "US", settingsChangedFlow = settingsChangedFlow)
         val viewModel = createViewModel()
-        advanceUntilIdle() // allow the collect coroutine in init to start
+        advanceUntilIdle()
 
         assertEquals("English", viewModel.currentLanguageDisplay.value)
 
@@ -170,7 +154,7 @@ class SettingsViewModelTest {
         val settingsChangedFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
         setupDefaultMocks(language = "en-US", region = "US", settingsChangedFlow = settingsChangedFlow)
         val viewModel = createViewModel()
-        advanceUntilIdle() // allow the collect coroutine in init to start
+        advanceUntilIdle()
 
         assertEquals("United States", viewModel.currentRegionDisplay.value)
 

--- a/composeApp/src/commonMain/kotlin/common/util/UiConstants.kt
+++ b/composeApp/src/commonMain/kotlin/common/util/UiConstants.kt
@@ -83,6 +83,13 @@ object UiConstants {
     const val PERSON_FEATURED_TITLE_MAX_LINES = 2
     const val CAROUSEL_RATING_STAR_SIZE = 18
 
+    // Settings
+    const val PROFILE_AVATAR_SIZE = 145
+    const val PROFILE_AVATAR_IMAGE_FRACTION = 0.8f
+    const val SETTINGS_AVATAR_BOTTOM_SPACING = 48
+    const val SETTINGS_BACK_ICON_SIZE = 24
+    const val SETTINGS_CHEVRON_ICON_SIZE = 20
+
     // IOS
     const val SYSTEM_BAR_HEIGHT = 150
 }

--- a/composeApp/src/commonMain/kotlin/features/settings/domain/SettingsInteractor.kt
+++ b/composeApp/src/commonMain/kotlin/features/settings/domain/SettingsInteractor.kt
@@ -32,8 +32,8 @@ class SettingsInteractor(private val settingsRepository: SettingsRepository) {
     fun setAppLanguage(languageTag: String) {
         val previousLanguage = getAppLanguage()
         settingsRepository.setAppLanguage(languageTag)
-        _settingsChanged.tryEmit(Unit)
         if (previousLanguage != languageTag) {
+            _settingsChanged.tryEmit(Unit)
             PlatformUtils.applyAppLocale(languageTag)
         }
     }
@@ -47,8 +47,11 @@ class SettingsInteractor(private val settingsRepository: SettingsRepository) {
     }
 
     fun setAppRegion(regionCode: String) {
+        val previousRegion = getAppRegion()
         settingsRepository.setAppRegion(regionCode)
-        _settingsChanged.tryEmit(Unit)
+        if (previousRegion != regionCode) {
+            _settingsChanged.tryEmit(Unit)
+        }
     }
 
     fun getSupportedLanguages(): List<LanguageItem> = SUPPORTED_LANGUAGES

--- a/composeApp/src/commonMain/kotlin/features/settings/events/SettingsEvent.kt
+++ b/composeApp/src/commonMain/kotlin/features/settings/events/SettingsEvent.kt
@@ -1,6 +1,6 @@
 package features.settings.events
 
 sealed class SettingsEvent {
-    data object LoadSettings : SettingsEvent()
-    data class NotificationToggled(val enabled: Boolean) : SettingsEvent()
+    data class NotificationPermissionResult(val granted: Boolean) : SettingsEvent()
+    data object DisableNotifications : SettingsEvent()
 }

--- a/composeApp/src/commonMain/kotlin/features/settings/ui/SettingsView.kt
+++ b/composeApp/src/commonMain/kotlin/features/settings/ui/SettingsView.kt
@@ -9,7 +9,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -25,7 +24,9 @@ import common.ui.theme.SecondaryGreyColor
 import common.util.UiConstants.DEFAULT_MARGIN
 import common.util.UiConstants.RETURN_TOP_BAR_HEIGHT
 import common.util.UiConstants.SECTION_PADDING
+import common.util.UiConstants.SETTINGS_AVATAR_BOTTOM_SPACING
 import common.util.platform.rememberNotificationPermissionLauncher
+import features.settings.events.SettingsEvent
 import features.settings.ui.components.ProfileAvatar
 import features.settings.ui.components.SettingsRow
 import features.settings.ui.components.SettingsToggleRow
@@ -35,30 +36,12 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun SettingsScreen(goToLanguagePicker: () -> Unit, goToRegionPicker: () -> Unit) {
     val viewModel: SettingsViewModel = koinViewModel()
-
-    LaunchedEffect(Unit) {
-        viewModel.refreshSettings()
-    }
-
-    SettingsContent(
-        viewModel = viewModel,
-        goToLanguagePicker = goToLanguagePicker,
-        goToRegionPicker = goToRegionPicker
-    )
-}
-
-@Composable
-private fun SettingsContent(
-    viewModel: SettingsViewModel,
-    goToLanguagePicker: () -> Unit,
-    goToRegionPicker: () -> Unit
-) {
     val currentLanguage by viewModel.currentLanguageDisplay.collectAsState()
     val currentRegion by viewModel.currentRegionDisplay.collectAsState()
     val notificationsEnabled by viewModel.notificationsEnabled.collectAsState()
 
     val requestPermission = rememberNotificationPermissionLauncher { granted ->
-        viewModel.onNotificationPermissionResult(granted)
+        viewModel.onEvent(SettingsEvent.NotificationPermissionResult(granted))
     }
 
     Column(
@@ -69,7 +52,7 @@ private fun SettingsContent(
     ) {
         ProfileAvatar()
 
-        Spacer(modifier = Modifier.height(SECTION_PADDING.dp * 2))
+        Spacer(modifier = Modifier.height(SETTINGS_AVATAR_BOTTOM_SPACING.dp))
 
         HorizontalDivider(color = MaterialTheme.colorScheme.inverseSurface)
 
@@ -102,7 +85,7 @@ private fun SettingsContent(
                 if (isEnabling) {
                     requestPermission()
                 } else {
-                    viewModel.disableNotifications()
+                    viewModel.onEvent(SettingsEvent.DisableNotifications)
                 }
             }
         )

--- a/composeApp/src/commonMain/kotlin/features/settings/ui/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/features/settings/ui/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import common.util.platform.AppNotifications
 import features.settings.domain.SettingsInteractor
+import features.settings.events.SettingsEvent
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -26,7 +27,14 @@ class SettingsViewModel(private val settingsInteractor: SettingsInteractor) : Vi
         }
     }
 
-    fun refreshSettings() {
+    fun onEvent(event: SettingsEvent) {
+        when (event) {
+            is SettingsEvent.NotificationPermissionResult -> handlePermissionResult(event.granted)
+            SettingsEvent.DisableNotifications -> disableNotifications()
+        }
+    }
+
+    private fun refreshSettings() {
         val currentLanguage = settingsInteractor.getAppLanguage()
         _currentLanguageDisplay.value = settingsInteractor.getSupportedLanguages()
             .find { it.tag == currentLanguage }?.displayName ?: currentLanguage
@@ -38,7 +46,7 @@ class SettingsViewModel(private val settingsInteractor: SettingsInteractor) : Vi
         _notificationsEnabled.value = settingsInteractor.areNotificationsEnabled()
     }
 
-    fun onNotificationPermissionResult(granted: Boolean) {
+    private fun handlePermissionResult(granted: Boolean) {
         if (granted) {
             settingsInteractor.setNotificationsEnabled(true)
             AppNotifications.scheduleEngagementReminders()
@@ -46,7 +54,7 @@ class SettingsViewModel(private val settingsInteractor: SettingsInteractor) : Vi
         }
     }
 
-    fun disableNotifications() {
+    private fun disableNotifications() {
         settingsInteractor.setNotificationsEnabled(false)
         AppNotifications.cancelEngagementReminders()
         _notificationsEnabled.value = false

--- a/composeApp/src/commonMain/kotlin/features/settings/ui/components/PickerTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/features/settings/ui/components/PickerTopBar.kt
@@ -14,9 +14,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import cinetracker_kmp.composeapp.generated.resources.Res
+import cinetracker_kmp.composeapp.generated.resources.back_arrow_description
 import cinetracker_kmp.composeapp.generated.resources.ic_back_arrow
 import common.util.UiConstants.DEFAULT_MARGIN
 import common.util.UiConstants.RETURN_TOP_BAR_HEIGHT
+import common.util.UiConstants.SETTINGS_BACK_ICON_SIZE
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -32,10 +34,10 @@ fun PickerTopBar(title: StringResource, onBack: () -> Unit) {
     ) {
         Icon(
             painter = painterResource(Res.drawable.ic_back_arrow),
-            contentDescription = null,
+            contentDescription = stringResource(resource = Res.string.back_arrow_description),
             tint = MaterialTheme.colorScheme.onPrimary,
             modifier = Modifier
-                .size(24.dp)
+                .size(SETTINGS_BACK_ICON_SIZE.dp)
                 .clickable(onClick = onBack)
         )
         Text(

--- a/composeApp/src/commonMain/kotlin/features/settings/ui/components/ProfileAvatar.kt
+++ b/composeApp/src/commonMain/kotlin/features/settings/ui/components/ProfileAvatar.kt
@@ -14,19 +14,21 @@ import androidx.compose.ui.unit.dp
 import cinetracker_kmp.composeapp.generated.resources.Res
 import cinetracker_kmp.composeapp.generated.resources.avatar
 import common.ui.theme.MainBarGreyColor
+import common.util.UiConstants.PROFILE_AVATAR_IMAGE_FRACTION
+import common.util.UiConstants.PROFILE_AVATAR_SIZE
 import org.jetbrains.compose.resources.painterResource
 
 @Composable
 fun ProfileAvatar(modifier: Modifier = Modifier) {
     Box(
         modifier = modifier
-            .size(145.dp)
+            .size(PROFILE_AVATAR_SIZE.dp)
             .clip(CircleShape)
             .background(MainBarGreyColor),
         contentAlignment = Alignment.Center
     ) {
         Image(
-            modifier = Modifier.fillMaxSize(fraction = 0.8f),
+            modifier = Modifier.fillMaxSize(fraction = PROFILE_AVATAR_IMAGE_FRACTION),
             painter = painterResource(Res.drawable.avatar),
             contentDescription = null
         )

--- a/composeApp/src/commonMain/kotlin/features/settings/ui/components/SettingsRow.kt
+++ b/composeApp/src/commonMain/kotlin/features/settings/ui/components/SettingsRow.kt
@@ -18,6 +18,7 @@ import cinetracker_kmp.composeapp.generated.resources.ic_chevron_right
 import common.ui.theme.SecondaryGreyColor
 import common.util.UiConstants.DEFAULT_MARGIN
 import common.util.UiConstants.DEFAULT_PADDING
+import common.util.UiConstants.SETTINGS_CHEVRON_ICON_SIZE
 import common.util.UiConstants.SETTINGS_ROW_HEIGHT
 import org.jetbrains.compose.resources.painterResource
 
@@ -47,7 +48,7 @@ fun SettingsRow(label: String, value: String, onClick: () -> Unit) {
             painter = painterResource(Res.drawable.ic_chevron_right),
             contentDescription = null,
             tint = SecondaryGreyColor,
-            modifier = Modifier.size(20.dp)
+            modifier = Modifier.size(SETTINGS_CHEVRON_ICON_SIZE.dp)
         )
     }
 }


### PR DESCRIPTION
## Summary
- Wire `SettingsEvent` into `SettingsViewModel` with `onEvent()` pattern, matching all other features
- Fix `settingsChanged` SharedFlow emission to only fire when values actually change (was emitting on no-op saves)
- Extract magic numbers (avatar size, icon sizes, spacing) to `UiConstants`
- Add accessibility `contentDescription` to back arrow in `PickerTopBar`
- Remove redundant `LaunchedEffect(Unit)` refresh — `init` + SharedFlow collection already handles it
- Flatten `SettingsView` by removing unnecessary `SettingsContent` wrapper
- Add `settingsChanged` emission tests for both `setAppLanguage` and `setAppRegion` using Turbine
- Document Settings feature in `features_details.md`