### PR TITLE
fix: add ProGuard keep rules for Google Sign-In on release builds

### DIFF
--- a/composeApp/proguard-rules.pro
+++ b/composeApp/proguard-rules.pro
@@ -21,6 +21,8 @@
 #-renamesourcefileattribute SourceFile
 
 -dontwarn org.slf4j.impl.StaticLoggerBinder
+-dontwarn java.lang.management.ManagementFactory
+-dontwarn java.lang.management.RuntimeMXBean
 
 # With R8 full mode generic signatures are stripped for classes that are not
 # kept. Suspend functions are wrapped in continuations where the type argument
@@ -28,3 +30,7 @@
 -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
 
 -keep class network.models.** { *; }
+
+# Google Sign-In / Credential Manager
+-keep class com.google.android.libraries.identity.googleid.** { *; }
+-keep class androidx.credentials.** { *; }


### PR DESCRIPTION
## Summary

- Add `-keep` rules for `com.google.android.libraries.identity.googleid.**` and `androidx.credentials.**` so R8 does not strip Credential Manager classes in release builds
- Add `-dontwarn` rules for JVM management classes referenced by Ktor's debug detector (dead code on Android)
- Fixes Google Sign-In failing silently on release builds while working fine on debug